### PR TITLE
fix: resize mask to match image resolution before reshape

### DIFF
--- a/models/diffusion_vas/demo.py
+++ b/models/diffusion_vas/demo.py
@@ -121,7 +121,7 @@ def load_and_transform_rgbs(image_folder, resolution=(512, 1024)):
 
     rgb_tensor = torch.stack(transformed_frames).unsqueeze(0)
 
-    return rgb_tensor, original_size, np.array(raw_images)
+    return rgb_tensor, original_size, np.array([cv2.resize(img, (original_size[1], original_size[0])) if img.shape[:2] != tuple(original_size) else img for img in raw_images])
 
 
 def rgb_to_depth(rgb_tensor, depth_model):

--- a/models/sam_3d_body/sam_3d_body/sam_3d_body_estimator.py
+++ b/models/sam_3d_body/sam_3d_body/sam_3d_body_estimator.py
@@ -167,7 +167,17 @@ class SAM3DBodyEstimator:
                 assert (
                     bboxes[i] is not None
                 ), "Mask-conditioned inference requires bboxes input!"
-                masks_binary = masks[i].reshape(-1, height, width, 1).astype(np.uint8)
+                mask_i = masks[i]
+                mask_h, mask_w = mask_i.shape[-2], mask_i.shape[-1]
+                if mask_h != height or mask_w != width:
+                    if mask_i.ndim == 2:
+                        mask_i = cv2.resize(mask_i, (width, height), interpolation=cv2.INTER_NEAREST)
+                    else:
+                        mask_i = np.stack([
+                            cv2.resize(m, (width, height), interpolation=cv2.INTER_NEAREST)
+                            for m in mask_i
+                        ])
+                masks_binary = mask_i.reshape(-1, height, width, 1).astype(np.uint8)
                 masks_score = np.ones(
                     len(masks), dtype=np.float32
                 )  # Set high confidence for provided masks


### PR DESCRIPTION
When mask and image have different resolutions (e.g. mask 1920x1080 vs image 720x1280), the reshape in sam_3d_body_estimator fails with ValueError. Add cv2.resize with INTER_NEAREST before reshape to handle resolution mismatch. Also normalize raw_images sizes in diffusion_vas demo to prevent frame stacking errors.