### PR TITLE
Cut CPU peak memory usage in half during video loading

### DIFF
--- a/models/sam3/sam3/model/utils/sam2_utils.py
+++ b/models/sam3/sam3/model/utils/sam2_utils.py
@@ -284,8 +284,6 @@ def load_video_frames_from_video_file(
     for frame in decord.VideoReader(video_path, width=image_size, height=image_size):
         images.append(frame.permute(2, 0, 1))
 
-    #images = torch.stack(images, dim=0).float() / 255.0
-    # NOTE: line above uses 3x amount of (peak) memory of line below
     images = torch.stack(images, dim=0).to(torch.float32).div_(255.0)
     if not offload_video_to_cpu:
         images = images.to(compute_device)

--- a/models/sam3/sam3/model/utils/sam2_utils.py
+++ b/models/sam3/sam3/model/utils/sam2_utils.py
@@ -284,7 +284,9 @@ def load_video_frames_from_video_file(
     for frame in decord.VideoReader(video_path, width=image_size, height=image_size):
         images.append(frame.permute(2, 0, 1))
 
-    images = torch.stack(images, dim=0).float() / 255.0
+    #images = torch.stack(images, dim=0).float() / 255.0
+    # NOTE: line above uses 3x amount of (peak) memory of line below
+    images = torch.stack(images, dim=0).to(torch.float32).div_(255.0)
     if not offload_video_to_cpu:
         images = images.to(compute_device)
         img_mean = img_mean.to(compute_device)


### PR DESCRIPTION
The video loading function contained a memory-intensive not-in-place operation, which when replaced with an in-place alternative shrinks the CPU memory peak in half. 

For example, with the 3min-long video I tested it with, it reduced from ~40GB --> ~20GB as depicted in the flame graphs below, thereby enabling it to run on machines with significantly less resources, especially when `offload_video_to_cpu` is enabled.

**Before: not-in-place operation**
<img width="894" height="222" alt="Screenshot 2026-03-25 at 21 04 55" src="https://github.com/user-attachments/assets/2dc82f71-8397-47e3-b73c-adcc90c07f14" />


**After: changing to in-place operation**
<img width="1340" height="456" alt="image" src="https://github.com/user-attachments/assets/00942960-b21f-4361-9c1c-023dc330d9d4" />

To the best of my knowledge, with limited testing, this has no (negative) effect on the output or other functionality in this repository.
